### PR TITLE
Add MIT license and document CC BY-SA data

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 wiewarm.ch contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -75,3 +75,30 @@ https://wie-warm.web.app/
 ## Credits
 
 - Externe Icons und Bilder findest du in [CREDITS.md](./CREDITS.md).
+
+## 📝 Lizenz
+
+### Code
+
+Der Code in diesem Repository steht unter der [MIT License](./LICENSE).
+
+### Daten
+
+Alle auf wiewarm.ch erhobenen Daten unterstehen der CC BY-SA 3.0 Lizenz. Das heisst dass die Daten frei kopiert und adaptiert werden können, solange folgende Bedingungen eingehalten werden:
+
+- **Namensnennung** – Sie müssen den Namen des Autors/Rechteinhabers in der von ihm festgelegten Weise nennen. In unserem Fall ist dies:
+  "http://www.wiewarm.ch sowie teilnehmende Badeanstalten und Individuen"
+  Falls es das Medium erlaubt, sollte die URL ein Hyperlink sein.
+- **Weitergabe unter gleichen Bedingungen** — Wenn Sie das lizenzierte Werk bzw. den lizenzierten Inhalt bearbeiten oder in anderer Weise erkennbar als Grundlage für eigenes Schaffen verwenden, dürfen Sie die daraufhin neu entstandenen Werke bzw. Inhalte nur unter Verwendung von Lizenzbedingungen weitergeben, die mit denen dieses Lizenzvertrages identisch oder vergleichbar sind.
+
+```
+Creative Commons License
+
+The full dataset of wiewarm.ch by http://www.wiewarm.ch and contributing baths
+and individuals is licensed under a Creative Commons Attribution-ShareAlike
+3.0 Unported License.
+
+Based on a work at http://www.wiewarm.ch.
+Permissions beyond the scope of this license may be available at
+mailto:info@wiewarm.ch.
+```

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ https://wie-warm.web.app/
 
 - Externe Icons und Bilder findest du in [CREDITS.md](./CREDITS.md).
 
-## 📝 Lizenz
+## 📝 Lizenz - ds Legalese chunnt itz in Hochdütsch
 
 ### Code
 

--- a/app/package.json
+++ b/app/package.json
@@ -10,6 +10,7 @@
     "deploy": "npx firebase deploy --only hosting"
   },
   "private": true,
+  "license": "MIT",
   "dependencies": {
     "@angular-devkit/build-angular": "^20.0.1",
     "@angular/animations": "^20.0.2",


### PR DESCRIPTION
## Summary
- add MIT License file covering code
- document CC BY-SA 3.0 terms for data in README
- set package.json license to MIT

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68a44e1d4f548321b8bac0062914c360