### PR TITLE
feat: make API backend configurable via environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ https://wie-warm.web.app/
 3. Startet d App im Entwickligsmodus
 
    ```bash
-   npm run start
+   # API-Endpoint chan via Umgebigsvariable chonfiguriert werde
+   NG_APP_API_BASE=https://beta.wiewarm.ch/api/v1 npm run start
    ```
 
 ## Support

--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
+    "start": "ng serve --proxy-config proxy.conf.cjs",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",

--- a/app/proxy.conf.cjs
+++ b/app/proxy.conf.cjs
@@ -1,0 +1,11 @@
+const apiBase = process.env.NG_APP_API_BASE || 'https://beta.wiewarm.ch/api/v1';
+const target = new URL(apiBase).origin;
+
+module.exports = {
+  '/api': {
+    target,
+    secure: false,
+    changeOrigin: true,
+    logLevel: 'debug',
+  },
+};

--- a/app/proxy.conf.json
+++ b/app/proxy.conf.json
@@ -1,8 +1,0 @@
-{
-  "/api": {
-    "target": "https://beta.wiewarm.ch:443",
-    "secure": false,
-    "changeOrigin": true,
-    "logLevel": "debug"
-  }
-}

--- a/app/src/app/shared/services/bad.service.spec.ts
+++ b/app/src/app/shared/services/bad.service.spec.ts
@@ -1,0 +1,40 @@
+import { BadResourceService } from './bad.service';
+import { environment } from '../../../environments/environment';
+
+describe('BadResourceService API base', () => {
+  jasmine.getEnv().allowRespy(true);
+
+  const dummyDetail = { badname: '', plz: '', ort: '' } as any;
+
+  it('uses beta host when configured', async () => {
+    environment.apiBase = 'https://beta.wiewarm.ch/api/v1';
+    const fetchSpy = spyOn(globalThis, 'fetch').and.resolveTo({
+      ok: true,
+      json: async () => dummyDetail,
+    } as Response);
+
+    const service = new BadResourceService();
+    await (service as any).loadDetail('foo');
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://beta.wiewarm.ch/api/v1/bad/foo',
+      { signal: undefined }
+    );
+  });
+
+  it('uses www host when configured', async () => {
+    environment.apiBase = 'https://www.wiewarm.ch/api/v1';
+    const fetchSpy = spyOn(globalThis, 'fetch').and.resolveTo({
+      ok: true,
+      json: async () => dummyDetail,
+    } as Response);
+
+    const service = new BadResourceService();
+    await (service as any).loadDetail('foo');
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://www.wiewarm.ch/api/v1/bad/foo',
+      { signal: undefined }
+    );
+  });
+});

--- a/app/src/environments/environment.prod.ts
+++ b/app/src/environments/environment.prod.ts
@@ -1,3 +1,6 @@
+const apiBase =
+  (import.meta as any).env?.NG_APP_API_BASE ?? 'https://beta.wiewarm.ch/api/v1';
+
 export const environment = {
-  apiBase: 'https://beta.wiewarm.ch/api/v1'
+  apiBase,
 };

--- a/app/src/environments/environment.ts
+++ b/app/src/environments/environment.ts
@@ -1,3 +1,6 @@
+const apiBase =
+  (import.meta as any).env?.NG_APP_API_BASE ?? 'https://beta.wiewarm.ch/api/v1';
+
 export const environment = {
-  apiBase: 'https://beta.wiewarm.ch/api/v1'
+  apiBase,
 };

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -1,5 +1,4 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import { appConfig } from './app/app.config';
 import { App } from './app/app';
-
 bootstrapApplication(App, appConfig).catch((err) => console.error(err));


### PR DESCRIPTION
## Summary
- allow configuring API backend through NG_APP_API_BASE env var
- derive dev proxy target from the same environment variable
- document how to set NG_APP_API_BASE during development
- drop runtime API preconnect injection and keep static link
- add unit test verifying BadResourceService uses the configured API host

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a44e6dee4c8321a1232b32266d601c